### PR TITLE
ft: Add files required for packaging the application

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,14 @@
+Copyright © 2014 for Click by the Pallets team
+
+Copyright © 2019 for the Click CLI News API by Leni Kadali Mutungi
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,0 +1,1 @@
+name = "click-cli-news-api"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+from setuptools import find_packages, setup
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name="click-cli-news-api",
+    version="1.0",
+    author="Leni Kadali Mutungi",
+    author_email="lenikmutungi@gmail.com",
+    description="Commandline app that uses Click and News API",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/leni1/click-cli-news-api",
+    classifiers=[
+        "Environment :: Console",
+        "Programming Language :: Python :: 3 :: Only",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Natural Language :: English",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: News/Diary",
+    ],
+    keywords="click cli commandline news api",
+    project_urls={
+        'Source': 'https://github.com/leni1/click-cli-news-api',
+    },
+    packages=find_packages(
+        exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    install_requires=["Click", ],
+    python_requires=">=3",
+    entry_points={
+        "console_scripts": [
+            "news=client.cli:get_news_items"
+        ]
+    },
+)
+


### PR DESCRIPTION
Added the files required for packaging the application namely the `LICENSE file`, the name of the application in the `client` package's `init` module and the `setup` module for specifying the rest of the package details.